### PR TITLE
Use "shell" instead of "terminal" in code block language tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Get a [Google Places API Key](https://developers.google.com/places/web-service/g
 
 ## Install
 
-```terminal
+```shell
 npm install --save gatsby-source-google-places
 # or
 yarn add gatsby-source-google-places


### PR DESCRIPTION
This is to silence prism highlighter warnings -- `terminal` is not on the list of [officially supported language tags](https://prismjs.com/#languages-list) but `shell` is. Thanks!