### PR TITLE
version bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/franklintarter/gatsby-source-google-places/issues"
   },
   "main": "index.js",
-  "version": "0.0.9",
+  "version": "1.0.0",
   "keywords": [
     "gatsby",
     "gatsby-plugin",
@@ -27,7 +27,7 @@
     "cross-env": "^5.1.4"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Followed the migration path for Gatsby 4. No changes were needed. Bumped versions as needed.